### PR TITLE
RFE to list the available scripts and execute a single script

### DIFF
--- a/utils
+++ b/utils
@@ -8,10 +8,12 @@ This script will run a minimum set of checks to an OpenShift cluster
 
 Available options:
 
--h, --help      Print this help and exit
--v, --verbose   Print script debug info
---no-info       Disable cluster info commands (default: enabled)
---no-checks     Disable cluster check commands (default: enabled)
+-h, --help                        Print this help and exit
+-v, --verbose                     Print script debug info
+-l, --list                        Lists the available checks
+-s <script>, --single <script>    Executes only the provided script (disables info by default)
+--no-info                         Disable cluster info commands (default: enabled)
+--no-checks                       Disable cluster check commands (default: enabled)
 EOF
   exit
 }
@@ -56,6 +58,13 @@ parse_params() {
     -v | --verbose)
       set -x
       ;;
+    -l | --list)
+      SINGLE=2
+      ;;
+    -s | --single)
+      SINGLE=1
+      SCRIPT_PROVIDED=${2}
+      ;;
     --no-color)
       NO_COLOR=1
       ;;
@@ -91,7 +100,9 @@ kubeconfig() {
   if [ -z "${CONTEXT}" ]; then
     die "${RED}KUBECONFIG not set${NOCOLOR}" 1
   else
-    msg "Using ${GREEN}${CONTEXT}${NOCOLOR} context"
+    if [ ${INFO} -ne 0 ]; then
+        msg "Using ${GREEN}${CONTEXT}${NOCOLOR} context"
+    fi
   fi
 }
 


### PR DESCRIPTION
Allows to execute only one check:
```
./openshift-checks.sh -s operators 
Using openshift-sriov-network-operator/rna1-vmaster-2:6443/kube:admin context
Operators in Bad State (2):
image-registry                             4.4.5   False   False   True    84d
openshift-samples                          4.4.5   False   True    True    42s
```
Allows to list the available scripts for specific checks:
```
./openshift-checks.sh -l --no-info
Available scripts:
alertmanager
chronyc
clusterversion_errors
csr
entropy
iptables-22623-22624
mcp
nodes
notrunningpods
operators
restarts
terminating
```

closes #6