### PR TITLE
Display node and namespace in alerts if applicable

### DIFF
--- a/checks/alertmanager
+++ b/checks/alertmanager
@@ -4,10 +4,9 @@
 
 if oc auth can-i get routes -n openshift-monitoring > /dev/null 2>&1; then
   alert_url=$(oc -n openshift-monitoring get routes/alertmanager-main -o json | jq -r .spec.host)
-  alerts=$(curl -s -k -H "Authorization: Bearer $(oc -n openshift-monitoring sa get-token prometheus-k8s)" https://$alert_url/api/v1/alerts | jq '.data[].labels |  {alert: .alertname, severity: .severity} | select((.severity == "warning") or (.severity == "critical"))')
-
+  alerts=$(curl -s -k -H "Authorization: Bearer $(oc -n openshift-monitoring sa get-token prometheus-k8s)" https://$alert_url/api/v1/alerts | jq '.data[].labels |  {alert: .alertname, severity: .severity, namespace: .namespace, instance: .instance} | select((.severity == "warning") or (.severity == "critical"))')
   if [[ -n ${alerts} ]]; then
-    ALERTS=$(echo "${alerts}" | jq -r '. | "\(.severity)\t\(.alert)"' | column -t -N "SEVERITY,ALERT")
+    ALERTS=$(echo "${alerts}" | jq -r '. | "\(.severity)\t\(.alert)\t\(.namespace)\t\(.instance)"' | column -t -N "SEVERITY,ALERT,NAMESPACE,INSTANCE")
     msg "Alerts currently firing:\n${RED}${ALERTS}${NOCOLOR}\n"
     errors=$(("${errors}"+1))
   fi

--- a/info/intel-firmware-version
+++ b/info/intel-firmware-version
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # lspci -nn shows PCI vendor and device codes (and names)
-# For mellanox connectx-4 = 15b3:1015
+# For intel xxv710 = 15b3:1015
 INTELID="8086:158a"
 
 if oc auth can-i debug node > /dev/null 2>&1; then

--- a/info/intel-firmware-version
+++ b/info/intel-firmware-version
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# lspci -nn shows PCI vendor and device codes (and names)
+# For mellanox connectx-4 = 15b3:1015
+INTELID="8086:158a"
+
+if oc auth can-i debug node > /dev/null 2>&1; then
+  msg "Checking Intel firmware version (${BLUE}using oc debug, it can take a while${NOCOLOR})"
+  for node in $(oc get nodes -o name); do
+    FIRMWAREVERS=$(oc debug "${node}" -- chroot /host sh -c "for device in \$(lspci -D -d "${INTELID}" | awk '{ print \$1 }'); do echo -n \"\${device} => \"; lspci -vv -D -s "\${device}" | egrep \"\[V0\]\" | awk '{print \$NF}' ;done" 2> /dev/null)
+    if [ -n "${FIRMWAREVERS}" ]; then
+      msg "${node}:\n${FIRMWAREVERS}"
+    else
+      msg "Couldn't find Intel firmware version in ${node}"
+    fi
+  done
+else
+  msg "Couldn't debug nodes, check permissions"
+fi


### PR DESCRIPTION
Will show a relevant namespace and node if available for a given alert, or null if n/a:
~~~
Alerts currently firing:
SEVERITY  ALERT                               NAMESPACE                  INSTANCE
warning   AlertmanagerReceiversNotConfigured  null                       null
critical  CannotRetrieveUpdates               openshift-cluster-version  10.19.33.2:9099
warning   NodeTextFileCollectorScrapeError  openshift-monitoring  node1.cloud.xana.du
warning   NodeTextFileCollectorScrapeError  openshift-monitoring  node2.cloud.xana.du
warning   NodeTextFileCollectorScrapeError  openshift-monitoring  node0.cloud.xana.du

Total issues found: 1
~~~