### PR TITLE
Changes required for Cronjob

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi:latest
+FROM registry.redhat.io/openshift4/ose-cli:latest
 
 WORKDIR /opt/openshift-checks
 

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -43,6 +43,11 @@ spec:
           - name: checks-openshift
             image: quay.io/dcritch/openshift-checks:latest
             imagePullPolicy: IfNotPresent
+            command: [
+              "/bin/sh",
+              "-c",
+              "/opt/openshift-checks/openshift-checks.sh || exit 0",
+              ]
             resources:
               requests:
                 cpu: 100m

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -46,7 +46,7 @@ spec:
             command: [
               "/bin/sh",
               "-c",
-              "/opt/openshift-checks/openshift-checks.sh || exit 0",
+              "/opt/openshift-checks/openshift-checks.sh",
               ]
             resources:
               requests:
@@ -55,6 +55,7 @@ spec:
           serviceAccountName: checks-openshift
           restartPolicy: Never
           terminationGracePeriodSeconds: 30
+      backoffLimit: 0
   schedule: "53 * * * *"
   successfulJobsHistoryLimit: 3
   suspend: false

--- a/utils
+++ b/utils
@@ -105,7 +105,7 @@ check_command() {
 }
 
 kubeconfig() {
-  CONTEXT=$(oc config current-context 2> /dev/null)
+  CONTEXT=$(oc whoami 2> /dev/null)
   if [ -z "${CONTEXT}" ]; then
     die "${RED}KUBECONFIG not set${NOCOLOR}" 1
   else


### PR DESCRIPTION
1/ Use the ose-cli container for the base (already worked out oc login logic)
2/ add explicit command so we can ` || exit 0` when an issue is found, without causing a bunch of pod restarts
3/ change the KUBECONFIG test. (no current-context in ose-cli)

Fixes #33 