### PR TITLE
Update to latest packages when the image is built

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,7 @@ WORKDIR /opt/openshift-checks
 
 RUN dnf clean all && \
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf update -y && \
     dnf install -y jq curl util-linux && \
     dnf clean all
 


### PR DESCRIPTION
Even if I don't like to update the packages already included in a container (it is a 'bad practice' because it breaks the reproducibility), there are currently some vulnerabilities considered 'high' (https://access.redhat.com/errata/RHSA-2021:0670) that are not included in the container image we use as a base.