### PR TITLE
fixing jq parsing in nodes script

### DIFF
--- a/checks/nodes
+++ b/checks/nodes
@@ -3,13 +3,13 @@
 if oc auth can-i get nodes > /dev/null 2>&1; then
   nodes_not_ready=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, type: .status.conditions[] } | select ((.type.type == "Ready") and (.type.status == "False"))')
   if [[ -n ${nodes_not_ready} ]]; then
-    NODESNOTREADY=$(echo "${nodes_not_ready}" | jq)
+    NODESNOTREADY=$(echo "${nodes_not_ready}" | jq .)
     msg "Nodes ${RED}NotReady${NOCOLOR}: ${NODESNOTREADY}"
     errors=$(("${errors}"+1))
   fi
   disabled_nodes=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, status: .metadata.labels."kubevirt.io/schedulable" } | select (.status == "false")')
   if [[ -n $disabled_nodes ]]; then
-    NODESDISABLED=$(echo "${disabled_nodes}" | jq)
+    NODESDISABLED=$(echo "${disabled_nodes}" | jq .)
     msg "Nodes ${RED}Disabled{$NOCOLOR}: ${NODESDISABLED}"
     errors=$(("${errors}"+1))
   fi


### PR DESCRIPTION
In Fedora, 'echo something | jq' is fine, but in RHEL8 you need to '| jq .'