### PR TITLE
fixing nodes in NotReady Status

### DIFF
--- a/checks/nodes
+++ b/checks/nodes
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if oc auth can-i get nodes > /dev/null 2>&1; then
-  nodes_not_ready=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, type: .status.conditions[] } | select ((.type.type == "Ready") and (.type.status == "False"))')
+  nodes_not_ready=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, type: .status.conditions[] } | select ((.type.type == "Ready") and (.type.status != "True"))')
   if [[ -n ${nodes_not_ready} ]]; then
     NODESNOTREADY=$(echo "${nodes_not_ready}" | jq .)
     msg "Nodes ${RED}NotReady${NOCOLOR}: ${NODESNOTREADY}"


### PR DESCRIPTION
closes #50 
$ ./openshift-checks.sh -s checks/nodes 
Using kube:admin context
Nodes NotReady: {
  "name": "*-master-*.com",
  "type": {
    "lastHeartbeatTime": "2021-04-15T10:06:10Z",
    "lastTransitionTime": "2021-04-15T10:11:06Z",
    "message": "Kubelet stopped posting node status.",
    "reason": "NodeStatusUnknown",
    "status": "Unknown",
    "type": "Ready"
  }
}
Total issues found: 1
