### PR TITLE
Detect a hung kubelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ in the [info](./info) or [checks](./checks) folders.
 | Script                                                | Description                                                                                                               |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | [alertmanager](checks/alertmanager)                   | Checks if there are warning or error alerts firing                                                                        |
+| [bz1941840](checks/bz1941840)                         | Checks if the openshift-authentication-operator is using a lot of memory, indicating a hung kubelet.[BZ1941840](https://bugzilla.redhat.com/show_bug.cgi?id=1941840) |
 | [bz1948052](checks/bz1948052)                         | Checks if the node is using a kernel version affected by [BZ1948052](https://bugzilla.redhat.com/show_bug.cgi?id=1948052) |
 | [chronyc](checks/chronyc)                             | Checks if the worker clocks are synced using chronyc                                                                      |
 | [clusterversion_errors](checks/clusterversion_errors) | Checks if there are clusterversion errors                                                                                 |

--- a/checks/bz1941840
+++ b/checks/bz1941840
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if oc auth can-i debug node >/dev/null 2>&1; then
+  msg "Checking for a possibly hung kublet... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
+  # shellcheck disable=SC2016
+  node=$(oc get pods -n openshift-authentication-operator -o json | jq -r .items[0].spec.nodeName)
+  if ! AUTH_OPERATOR_MEMORY=$(oc debug --image="${OCDEBUGIMAGE}" node/"${node}" -- chroot /host sh -c 'crictl stats --id $(crictl ps --name authentication-operator -o json | jq -r .containers[0].id) -o json | jq -r .stats[0].memory.workingSetBytes.value'); then
+      msg "${ORANGE}Error running oc debug in ${node}${NOCOLOR}"
+    else
+      if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2147483648 ]; then
+        msg "${RED}High memory usage detected for openshift-authentication-operator, which likely means that kubelet on ${node} is hung. Terminate the pod to remediate${NOCOLOR}"
+        errors=$(("${errors}" + 1))
+      fi
+    fi
+else
+  msg "Couldn't debug nodes, check permissions"
+fi

--- a/checks/bz1941840
+++ b/checks/bz1941840
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
-if oc auth can-i debug node >/dev/null 2>&1; then
-  msg "Checking for a possibly hung kublet... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
+if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; then
+  msg "Checking for a hung kubelet..."
   # shellcheck disable=SC2016
   node=$(oc get pods -n openshift-authentication-operator -o json | jq -r .items[0].spec.nodeName)
-  if ! AUTH_OPERATOR_MEMORY=$(oc debug --image="${OCDEBUGIMAGE}" node/"${node}" -- chroot /host sh -c 'crictl stats --id $(crictl ps --name authentication-operator -o json | jq -r .containers[0].id) -o json | jq -r .stats[0].memory.workingSetBytes.value'); then
-      msg "${ORANGE}Error running oc debug in ${node}${NOCOLOR}"
+  pod=$(oc get pods -l app=authentication-operator -n openshift-authentication-operator -o json  | jq -r .items[0].metadata.name)
+  if ! AUTH_OPERATOR_MEMORY=$(oc exec -n openshift-authentication-operator $pod --  ps -o rss -p 1 --no-headers); then
+      msg "${ORANGE}Error running oc exec on pod openshift-authentication-operator/${pod}${NOCOLOR}"
     else
-      if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2147483648 ]; then
+      if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2097152 ]; then # more than 2GB is a bad sign
         msg "${RED}High memory usage detected for openshift-authentication-operator, which likely means that kubelet on ${node} is hung. Terminate the pod to remediate${NOCOLOR}"
         errors=$(("${errors}" + 1))
       fi
     fi
 else
-  msg "Couldn't debug nodes, check permissions"
+  msg "Couldn't get pods, check permissions"
 fi


### PR DESCRIPTION
This script checks to see if the openshift-authentication-operator is using a lot of memory, which is a good indicator of a hung kubelet (https://bugzilla.redhat.com/show_bug.cgi?id=1941840)

Fixes #64 