### PR TITLE
Adding SSH check for hung kubelet/excessive authentication-operator consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Available options:
 -s <script>, --single <script>           Executes only the provided script
 --no-info                                Disable cluster info commands (default: enabled)
 --no-checks                              Disable cluster check commands (default: enabled)
+--no-ssh                                 Disable ssh-based check commands (default: enabled)
 --prechecks path/to/install-config.yaml  Executes only prechecks (default: disabled)
 
 With no options, it will run all checks and info commands with no debug info
@@ -85,7 +86,7 @@ Check the [cronjob.yaml](cronjob.yaml) example.
 ## How it works
 
 The `openshift-checks.sh` script is just a wrapper around bash scripts located
-in the [info](./info) or [checks](./checks) folders.
+in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 
 ### Checks
 
@@ -106,6 +107,12 @@ in the [info](./info) or [checks](./checks) folders.
 | [port-thrasing](checks/port-thrasing)                 | Checks if there are OVN pods thrasing                                                                                     |
 | [restarts](checks/restarts)                           | Checks if there are pods restarted > `n` times (10 by default)                                                            |
 | [terminating](checks/terminating)                     | Checks if there are pods terminating                                                                                      |
+
+### SSH Checks
+
+| Script                                                | Description                                                                                                                                   |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [bz1941840](ssh/bz1941840)                            | Checks if the authentication-operator is using excessive RAM -> hung kubelet [BZ1941840](https://bugzilla.redhat.com/show_bug.cgi?id=1948052) |
 
 ### Info
 

--- a/openshift-checks.sh
+++ b/openshift-checks.sh
@@ -22,6 +22,7 @@ errors=0
 INFO=1
 CHECKS=1
 PRE=0
+SSH=1
 LIST=0
 SINGLE=0
 SCRIPT_PROVIDED=''
@@ -38,7 +39,7 @@ main() {
   # Check if only list is needed
   if [ "${LIST}" -ne 0 ]; then
     msg "${GREEN}Available scripts:${NOCOLOR}"
-    find checks/ info/ pre/ -type f | sort -n
+    find checks/ info/ pre/ ssh/ -type f | sort -n
     exit 0
   else
     # Check binaries availability
@@ -84,6 +85,16 @@ main() {
           export errors=$(expr $(cat ${ERRORFILE}) + 0)
           # shellcheck disable=SC1090,SC1091
           "${check}"
+        done
+      fi
+      # If only ssh checks are needed:
+      if [ "${SSH}" -gt 0 ]; then
+        msg "Running ssh-based health checks as ${GREEN}${OCUSER}${NOCOLOR}"
+        for ssh in ./ssh/*; do
+          # Refresh error count before execution
+          export errors=$(expr $(cat ${ERRORFILE}) + 0)
+          # shellcheck disable=SC1090,SC1091
+          "${ssh}"
         done
       fi
     fi

--- a/ssh/bz1941840
+++ b/ssh/bz1941840
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+[ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
+
+if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; then
+  msg "Checking for a hung kubelet..."
+  # shellcheck disable=SC2016
+  node=$(oc get pods -n openshift-authentication-operator -l app=authentication-operator -o json | jq -r .items[0].spec.nodeName)
+    if ! AUTH_OPERATOR_MEMORY=$(ssh -q core@$node 'sudo crictl stats --id $(sudo crictl ps --name authentication-operator -o json | jq -r .containers[0].id) -o json | jq -r .stats[0].memory.workingSetBytes.value'); then
+      msg "${ORANGE}Error running crictl stats openshift-authentication-operator/${pod}${NOCOLOR}"
+    else
+      if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2147483648 ]; then # more than 2GB is a bad sign
+        msg "${RED}High memory usage detected for openshift-authentication-operator, which likely means that kubelet on ${node} is hung. Terminate the pod to remediate${NOCOLOR}"
+        errors=$(("${errors}" + 1))
+      fi
+    fi
+    if [ ! -z "${ERRORFILE}" ]; then
+      echo $errors >${ERRORFILE}
+    fi
+    if [ "errors" != "0" ]; then
+      exit ${OCERROR}
+    else
+      exit ${OCOK}
+    fi
+else
+  msg "Couldn't get pods, check permissions"
+  exit ${OCSKIP}
+fi
+exit ${OCUNKOWN}

--- a/ssh/bz1941840
+++ b/ssh/bz1941840
@@ -1,27 +1,30 @@
 #!/usr/bin/env bash
 
+# bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1948052
+
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
 if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; then
   msg "Checking for a hung kubelet..."
   # shellcheck disable=SC2016
   node=$(oc get pods -n openshift-authentication-operator -l app=authentication-operator -o json | jq -r .items[0].spec.nodeName)
-    if ! AUTH_OPERATOR_MEMORY=$(ssh -q core@$node 'sudo crictl stats --id $(sudo crictl ps --name authentication-operator -o json | jq -r .containers[0].id) -o json | jq -r .stats[0].memory.workingSetBytes.value'); then
-      msg "${ORANGE}Error running crictl stats openshift-authentication-operator/${pod}${NOCOLOR}"
-    else
-      if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2147483648 ]; then # more than 2GB is a bad sign
-        msg "${RED}High memory usage detected for openshift-authentication-operator, which likely means that kubelet on ${node} is hung. Terminate the pod to remediate${NOCOLOR}"
-        errors=$(("${errors}" + 1))
-      fi
+  container_id=$(oc get pods -n openshift-authentication-operator -l app=authentication-operator -o json  | jq -r .items[0].status.containerStatuses[0].containerID | awk -F// '{print $2}' | cut -c-13)
+  if ! AUTH_OPERATOR_MEMORY=$(ssh -q core@$node "sudo crictl stats --id ${container_id} -o json | jq -r .stats[0].memory.workingSetBytes.value"); then
+    msg "${ORANGE}Error running crictl stats openshift-authentication-operator/${pod}${NOCOLOR}"
+  else
+    if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2147483648 ]; then # more than 2GB is a bad sign
+      msg "${RED}High memory usage detected for openshift-authentication-operator, which likely means that kubelet on ${node} is hung. Terminate the pod to remediate${NOCOLOR}"
+      errors=$(("${errors}" + 1))
     fi
-    if [ ! -z "${ERRORFILE}" ]; then
-      echo $errors >${ERRORFILE}
-    fi
-    if [ "errors" != "0" ]; then
-      exit ${OCERROR}
-    else
-      exit ${OCOK}
-    fi
+  fi
+  if [ ! -z "${ERRORFILE}" ]; then
+    echo $errors >${ERRORFILE}
+  fi
+  if [ "errors" != "0" ]; then
+    exit ${OCERROR}
+  else
+    exit ${OCOK}
+  fi
 else
   msg "Couldn't get pods, check permissions"
   exit ${OCSKIP}

--- a/utils
+++ b/utils
@@ -24,6 +24,7 @@ Available options:
 -s <script>, --single <script>           Executes only the provided script
 --no-info                                Disable cluster info commands (default: enabled)
 --no-checks                              Disable cluster check commands (default: enabled)
+--no-ssh                                 Disable ssh-based check commands (default: enabled)
 --prechecks path/to/install-config.yaml  Executes only prechecks (default: disabled)
 
 With no options, it will run all checks and info commands with no debug info
@@ -96,10 +97,15 @@ parse_params() {
       # shellcheck disable=2034
       CHECKS=0
       ;;
+    --no-ssh)
+      # shellcheck disable=2034
+      SSH=0
+      ;;
     --prechecks)
       # shellcheck disable=2034
       CHECKS=0
       INFO=0
+      SSH=0
       PRE=1
       INSTALL_CONFIG_PATH=${2-}
       ;;


### PR DESCRIPTION
This change introduces SSH based checks, with the first one checking for high memory usage of the authentication-operator, which can be an indicator of a hung kubelet.