### PR TITLE
Adding the ovn-pods-memory-usage to check for OVN pods memory abuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | [port-thrasing](checks/port-thrasing)                 | Checks if there are OVN pods thrasing                                                                                     |
 | [restarts](checks/restarts)                           | Checks if there are pods restarted > `n` times (10 by default)                                                            |
 | [terminating](checks/terminating)                     | Checks if there are pods terminating                                                                                      |
+| [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) | Checks if the memory usage of the OVN pods is under the LIMIT threshold                                                   |
 
 ### SSH Checks
 
@@ -154,6 +155,7 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | RESTART_THRESHOLD    | 10                                                   | Used by the [restarts](checks/restarts) script.                                   |
 | THRASING_THRESHOLD   | 10                                                   | Used by the [port-thrashing](checks/port-thrashing) script.                       |
 | PARALLELJOBS         | 1                                                    | By default, all the `oc debug` commands run in a serial fashion, unless this variable is set >1 |
+| OVN_MEMORY_LIMIT     | 1000                                                 | Used by the [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) script to set the maximum memory LIMIT (in Mi) to trigger the warning. |
 
 ### About firmware version
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | RESTART_THRESHOLD    | 10                                                   | Used by the [restarts](checks/restarts) script.                                   |
 | THRASING_THRESHOLD   | 10                                                   | Used by the [port-thrashing](checks/port-thrashing) script.                       |
 | PARALLELJOBS         | 1                                                    | By default, all the `oc debug` commands run in a serial fashion, unless this variable is set >1 |
-| OVN_MEMORY_LIMIT     | 1000                                                 | Used by the [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) script to set the maximum memory LIMIT (in Mi) to trigger the warning. |
+| OVN_MEMORY_LIMIT     | 5000                                                 | Used by the [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) script to set the maximum memory LIMIT (in Mi) to trigger the warning. |
 
 ### About firmware version
 

--- a/checks/nodes
+++ b/checks/nodes
@@ -10,9 +10,9 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
     errors=$(("${errors}" + 1))
   fi
   disabled_nodes=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, status: .spec.unschedulable } | select (.status == true)')
-  if [[ -n $disabled_nodes ]]; then
+  if [[ -n ${disabled_nodes} ]]; then
     NODESDISABLED=$(echo "${disabled_nodes}" | jq .)
-    msg "Nodes ${RED}Disabled{$NOCOLOR}: ${NODESDISABLED}"
+    msg "Nodes ${RED}Disabled${NOCOLOR}: ${NODESDISABLED}"
     errors=$(("${errors}" + 1))
   fi
   if [ ! -z "${ERRORFILE}" ]; then

--- a/checks/ovn-pods-memory-usage
+++ b/checks/ovn-pods-memory-usage
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+[ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
+
+
+if oc auth can-i adm top -A >/dev/null 2>&1; then
+  LIMIT="${OVN_MEMORY_LIMIT:=1000}"
+  FLAG=0
+#  pods_memory_total_usage=$(oc adm top pod -n openshift-ovn-kubernetes -l app=ovnkube-node --no-headers| awk '{ print $3 }' |awk '$1 ~ /[0-9\.]+Gi/ { $1 = int($1 * 1024) } {$1 = substr($1,0,length($1)-2)} { total = total + $1} END {printf("%g",total)} 1' | tail -n 1)
+  pods_memory_usage=$(oc adm top pod -n openshift-ovn-kubernetes -l app=ovnkube-node --no-headers| awk '{ print $1 " " $3 }' | awk '{$2 = substr($2,0,length($2)-2)}  1' )
+  MESSAGE=""
+
+  OLDIFS=${IFS}
+  IFS=$'\n'
+  for pod_line in ${pods_memory_usage}; do
+      pod_name=$(echo $pod_line | awk '{ print $1 }')
+      pod_size=$(echo $pod_line | awk '{ print $2 }')
+      if [[ ${pod_size} -ge ${LIMIT} ]]; then
+         MESSAGE="${MESSAGE}The OVN pod memory usage for ${pod_name} is extremely high: ${RED}${pod_size}${NOCOLOR}Mi\n"
+         FLAG=1
+      fi
+  done
+  IFS=${OLDIFS}
+         
+  if [[ ${FLAG} -ne 0 ]]; then
+    MESSAGE="${MESSAGE}For more information you can check the KCS https://access.redhat.com/solutions/6493321\n"
+    msg "${MESSAGE}"
+    errors=$(("${errors}" + 1))
+  fi
+
+  if [ ! -z "${ERRORFILE}" ]; then
+    echo $errors >${ERRORFILE}
+  fi
+
+  if [ "errors" != "0" ]; then
+    exit ${OCERROR}
+  else
+    exit ${OCOK}
+  fi
+else
+  msg "Couldn't adm top pods, check permissions"
+  exit ${OCSKIP}
+fi
+exit ${OCUNKOWN}

--- a/checks/ovn-pods-memory-usage
+++ b/checks/ovn-pods-memory-usage
@@ -4,9 +4,8 @@
 
 
 if oc auth can-i adm top -A >/dev/null 2>&1; then
-  LIMIT="${OVN_MEMORY_LIMIT:=1000}"
+  LIMIT="${OVN_MEMORY_LIMIT:=5000}"
   FLAG=0
-#  pods_memory_total_usage=$(oc adm top pod -n openshift-ovn-kubernetes -l app=ovnkube-node --no-headers| awk '{ print $3 }' |awk '$1 ~ /[0-9\.]+Gi/ { $1 = int($1 * 1024) } {$1 = substr($1,0,length($1)-2)} { total = total + $1} END {printf("%g",total)} 1' | tail -n 1)
   pods_memory_usage=$(oc adm top pod -n openshift-ovn-kubernetes -l app=ovnkube-node --no-headers| awk '{ print $1 " " $3 }' | awk '{$2 = substr($2,0,length($2)-2)}  1' )
   MESSAGE=""
 


### PR DESCRIPTION
Adding a new script to check for OVN pods memory usage.
Usage:
```
$ OVN_MEMORY_LIMIT=10 ./openshift-checks.sh -s checks/ovn-pods-memory-usage 
Using kube:admin context
The OVN pod memory usage for ovnkube-node-98hwm is extremely high: 220Mi
The OVN pod memory usage for ovnkube-node-cl4np is extremely high: 135Mi
The OVN pod memory usage for ovnkube-node-k2zv2 is extremely high: 210Mi
The OVN pod memory usage for ovnkube-node-mq4v4 is extremely high: 212Mi
The OVN pod memory usage for ovnkube-node-ssfht is extremely high: 126Mi
The OVN pod memory usage for ovnkube-node-x2vqj is extremely high: 135Mi
For more information you can check the KCS https://access.redhat.com/solutions/6493321

Total issues found: 1

$ OVN_MEMORY_LIMIT=200 ./openshift-checks.sh -s checks/ovn-pods-memory-usage 
Using kube:admin context
The OVN pod memory usage for ovnkube-node-98hwm is extremely high: 221Mi
The OVN pod memory usage for ovnkube-node-k2zv2 is extremely high: 210Mi
The OVN pod memory usage for ovnkube-node-mq4v4 is extremely high: 212Mi
For more information you can check the KCS https://access.redhat.com/solutions/6493321

Total issues found: 1
```