### PR TITLE
Fix OCERROR return codes

### DIFF
--- a/checks/bz1948052
+++ b/checks/bz1948052
@@ -7,6 +7,7 @@
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
 BADKERNEL="4.18.0-193.24.1.el8_2.dt1.x86_64"
+error=false
 
 if oc auth can-i get nodes >/dev/null 2>&1; then
   for node in $(oc get nodes -o go-template='{{range .items}}{{$node := .}}{{range .status.conditions}}{{if eq .type "Ready"}}{{if eq .status "True"}}node/{{$node.metadata.name}}{{"\n"}}{{end}}{{end}}{{end}}{{end}}'); do
@@ -14,12 +15,13 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
     if [[ ${kernel_version} == ${BADKERNEL} ]]; then
       msg "${RED}Node ${node} contains ${BADKERNEL} kernel version${NOCOLOR}"
       errors=$(("${errors}" + 1))
+      error=true
     fi
   done
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/bz1948052
+++ b/checks/bz1948052
@@ -21,7 +21,7 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/bz1948052
+++ b/checks/bz1948052
@@ -21,7 +21,7 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/chronyc
+++ b/checks/chronyc
@@ -27,7 +27,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/chronyc
+++ b/checks/chronyc
@@ -27,7 +27,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/chronyc
+++ b/checks/chronyc
@@ -2,6 +2,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Collecting NTP data... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
   # shellcheck disable=SC2016
@@ -16,6 +18,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
         if [ -n "${SOURCES}" ] && [ "${SOURCES}" -lt 1 ]; then
           msg "${RED}Clock doesn't seem to be synced in ${node}${NOCOLOR}"
           errors=$(("${errors}" + 1))
+          error=true
         fi
       fi
     ) &
@@ -24,7 +27,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/clusterversion_errors
+++ b/checks/clusterversion_errors
@@ -23,7 +23,7 @@ if oc auth can-i get clusterversion >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/clusterversion_errors
+++ b/checks/clusterversion_errors
@@ -2,6 +2,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get clusterversion >/dev/null 2>&1; then
   clusterversion_msgs=$(oc get clusterversion -o json | jq '.items[].status.conditions[] | select ((.status == "True") and (.type == "Failing") and (.message != null)) | { message: .message }')
   count_errors=$(echo "${clusterversion_msgs}" | jq .message | wc -l)
@@ -16,11 +18,12 @@ if oc auth can-i get clusterversion >/dev/null 2>&1; then
     IFS=${OLDIFS}
     msg "Clusterversion error status message: ${RED}${final}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/clusterversion_errors
+++ b/checks/clusterversion_errors
@@ -23,7 +23,7 @@ if oc auth can-i get clusterversion >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/csr
+++ b/checks/csr
@@ -15,7 +15,7 @@ if oc auth can-i get csr >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/csr
+++ b/checks/csr
@@ -15,7 +15,7 @@ if oc auth can-i get csr >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/csr
+++ b/checks/csr
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get csr >/dev/null 2>&1; then
   pending_csr=$(oc get csr --no-headers --ignore-not-found=true | grep -ci 'pending')
   if [[ ${pending_csr} -ge 1 ]]; then
     PCSR=$(oc get csr --no-headers | grep -i 'pending')
     msg "Pending CSRs (${pending_csr}): ${PCSR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -15,7 +15,7 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -15,7 +15,7 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get nodes >/dev/null 2>&1; then
   scheduable_controllers=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, scheduable: .spec.taints, control: .metadata.labels."node-role.kubernetes.io/master" } | select((.control == "") and (.scheduable == null))')
   if [[ -n ${scheduable_controllers} ]]; then
     SCHEDCTRL=$(echo "${scheduable_controllers}" | jq '. | { name: .name }')
     msg "Controllers ${RED}Scheduable${NOCOLOR}: ${SCHEDCTRL}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/entropy
+++ b/checks/entropy
@@ -2,6 +2,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Collecting entropy data... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
   # shellcheck disable=SC2016
@@ -15,6 +17,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
         if [ -n "${ENTROPY}" ] && [ "${ENTROPY}" -lt 200 ]; then
           msg "${RED}Low entropy in ${node}${NOCOLOR}"
           errors=$(("${errors}" + 1))
+          error=true
         fi
       fi
     ) &
@@ -23,7 +26,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/entropy
+++ b/checks/entropy
@@ -26,7 +26,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/entropy
+++ b/checks/entropy
@@ -26,7 +26,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/iptables-22623-22624
+++ b/checks/iptables-22623-22624
@@ -11,6 +11,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Checking if ports 22623/tcp and 22624/tcp are blocked (${BLUE}using oc debug, it can take a while${NOCOLOR})"
   # shellcheck disable=SC2016
@@ -38,6 +40,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
       else
         msg "${RED}iptables rules for 22623/tcp or 22624/tcp found in ${node}${NOCOLOR}"
         errors=$(("${errors}" + 1))
+        error=true
       fi
     ) &
   done
@@ -45,7 +48,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/iptables-22623-22624
+++ b/checks/iptables-22623-22624
@@ -48,7 +48,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/iptables-22623-22624
+++ b/checks/iptables-22623-22624
@@ -48,7 +48,7 @@ if oc auth can-i debug node >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/mcp
+++ b/checks/mcp
@@ -15,7 +15,7 @@ if oc auth can-i get mcp >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/mcp
+++ b/checks/mcp
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get mcp >/dev/null 2>&1; then
   degrated_mcps=$(oc get mcp -o json | jq '.items[] | { name: .metadata.name, status: .status } | select (.status.degradedMachineCount >= 1) | { name: .name, status: .status.degradedMachineCount}')
   if [[ -n $degrated_mcps ]]; then
     DEGRADED=$(echo "${degrated_mcps}" | jq .)
     msg "MachineConfigProfiles in Degraded State: ${RED}${DEGRADED}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/mcp
+++ b/checks/mcp
@@ -15,7 +15,7 @@ if oc auth can-i get mcp >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/nodes
+++ b/checks/nodes
@@ -22,7 +22,7 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/nodes
+++ b/checks/nodes
@@ -22,7 +22,7 @@ if oc auth can-i get nodes >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/nodes
+++ b/checks/nodes
@@ -2,23 +2,27 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get nodes >/dev/null 2>&1; then
   nodes_not_ready=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, type: .status.conditions[] } | select ((.type.type == "Ready") and (.type.status != "True"))')
   if [[ -n ${nodes_not_ready} ]]; then
     NODESNOTREADY=$(echo "${nodes_not_ready}" | jq .)
     msg "Nodes ${RED}NotReady${NOCOLOR}: ${NODESNOTREADY}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   disabled_nodes=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, status: .spec.unschedulable } | select (.status == true)')
   if [[ -n ${disabled_nodes} ]]; then
     NODESDISABLED=$(echo "${disabled_nodes}" | jq .)
     msg "Nodes ${RED}Disabled${NOCOLOR}: ${NODESDISABLED}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/notrunningpods
+++ b/checks/notrunningpods
@@ -17,7 +17,7 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/notrunningpods
+++ b/checks/notrunningpods
@@ -17,7 +17,7 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/notrunningpods
+++ b/checks/notrunningpods
@@ -2,6 +2,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get pods -A >/dev/null 2>&1; then
   # Get all nonrunning pods with headers even if they are not found
   notrunning=$(oc get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded --ignore-not-found=true)
@@ -10,11 +12,12 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [[ -n ${PODS} ]]; then
     msg "Pods not running ($(echo "${PODS}" | wc -l)):\n${HEADER}\n${RED}${PODS}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/operators
+++ b/checks/operators
@@ -15,7 +15,7 @@ if oc auth can-i get co >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/operators
+++ b/checks/operators
@@ -15,7 +15,7 @@ if oc auth can-i get co >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/operators
+++ b/checks/operators
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get co >/dev/null 2>&1; then
   bad_operators=$(oc get co --no-headers | grep -E -civ 'True.*False.*False')
   if [[ ${bad_operators} -ge 1 ]]; then
     BADOPS=$(oc get co --no-headers | grep -E -iv 'True.*False.*False')
     msg "Operators in Bad State (${bad_operators}):\n${RED}${BADOPS}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/ovn-pods-memory-usage
+++ b/checks/ovn-pods-memory-usage
@@ -2,6 +2,7 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
 
 if oc auth can-i adm top -A >/dev/null 2>&1; then
   LIMIT="${OVN_MEMORY_LIMIT:=5000}"
@@ -25,13 +26,14 @@ if oc auth can-i adm top -A >/dev/null 2>&1; then
     MESSAGE="${MESSAGE}For more information you can check the KCS https://access.redhat.com/solutions/6493321\n"
     msg "${MESSAGE}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
 
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
 
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/ovn-pods-memory-usage
+++ b/checks/ovn-pods-memory-usage
@@ -33,7 +33,7 @@ if oc auth can-i adm top -A >/dev/null 2>&1; then
     echo $errors >${ERRORFILE}
   fi
 
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/ovn-pods-memory-usage
+++ b/checks/ovn-pods-memory-usage
@@ -33,7 +33,7 @@ if oc auth can-i adm top -A >/dev/null 2>&1; then
     echo $errors >${ERRORFILE}
   fi
 
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/pdb
+++ b/checks/pdb
@@ -15,7 +15,7 @@ if oc auth can-i get pdb >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/pdb
+++ b/checks/pdb
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get pdb >/dev/null 2>&1; then
   wrong_pdb=$(oc get pdb -A -o json | jq '.items[] | { name: .metadata.name, status: .status } | select (.status.disruptionsAllowed == 0) | { name: .name}')
   if [[ -n $wrong_pdb ]]; then
     DEGRADED=$(echo "${wrong_pdb}" | jq .)
     msg "PodDisruptionBudget with 0 disruptions allowed: ${RED}${DEGRADED}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/pdb
+++ b/checks/pdb
@@ -15,7 +15,7 @@ if oc auth can-i get pdb >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/port-thrasing
+++ b/checks/port-thrasing
@@ -25,7 +25,7 @@ else
       if [ ! -z "${ERRORFILE}" ]; then
         echo $errors >${ERRORFILE}
       fi
-      if [[ "$error" = true ]]; then
+      if [[ "$error" == true ]]; then
         exit ${OCERROR}
       else
         exit ${OCOK}

--- a/checks/port-thrasing
+++ b/checks/port-thrasing
@@ -3,6 +3,8 @@
 THRASINGMSG="Changing chassis for lport"
 NAMESPACE="openshift-ovn-kubernetes"
 
+error=false
+
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
 if [[ $(oc get network/cluster -o jsonpath={.spec.networkType}) != "OVNKubernetes" ]]; then
@@ -16,11 +18,17 @@ else
         if [[ ${numerrors} -gt ${THRASING_THRESHOLD} ]]; then
           msg "${RED}${pod} port thrasing errors detected${NOCOLOR}"
           errors=$(("${errors}" + 1))
+          error=true
         fi
 
       done
       if [ ! -z "${ERRORFILE}" ]; then
         echo $errors >${ERRORFILE}
+      fi
+      if [ "$error" = true ]; then
+        exit ${OCERROR}
+      else
+        exit ${OCOK}
       fi
     else
       msg "Couldn't get pods logs, check permissions"

--- a/checks/port-thrasing
+++ b/checks/port-thrasing
@@ -25,7 +25,7 @@ else
       if [ ! -z "${ERRORFILE}" ]; then
         echo $errors >${ERRORFILE}
       fi
-      if [ "$error" = true ]; then
+      if [[ "$error" = true ]]; then
         exit ${OCERROR}
       else
         exit ${OCOK}

--- a/checks/restarts
+++ b/checks/restarts
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get pods -A >/dev/null 2>&1; then
   restarts=$(oc get pods -o json -A | jq -r ".items[] | { name: .metadata.name, project: .metadata.namespace, restarts: .status.containerStatuses[].restartCount } | select(.restarts > $RESTART_THRESHOLD)" 2>/dev/null)
   if [[ -n $restarts ]]; then
     RESTARTS=$(echo "${restarts}" | jq -r '. | "\(.project)\t\(.name)\t\(.restarts)"' | column -t -N "NAMESPACE,NAME,RESTARTS")
     msg "Pods that have a high restart count (> $RESTART_THRESHOLD):\n${RED}${RESTARTS}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/restarts
+++ b/checks/restarts
@@ -15,7 +15,7 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/restarts
+++ b/checks/restarts
@@ -15,7 +15,7 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/terminating
+++ b/checks/terminating
@@ -15,7 +15,7 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/terminating
+++ b/checks/terminating
@@ -2,17 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get pods -A >/dev/null 2>&1; then
   terminating_pods=$(oc get pods -A | grep -c 'Terminating')
   if [[ $terminating_pods -ge 1 ]]; then
     TERMPODS=$(oc get pods -A | grep 'Terminating')
     msg "Pods in Terminating state ($terminating_pods):\n${RED}${TERMPODS}${NOCOLOR}"
     errors=$(("${errors}" + 1))
+    error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/terminating
+++ b/checks/terminating
@@ -15,7 +15,7 @@ if oc auth can-i get pods -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/pre/dns-hostnames
+++ b/pre/dns-hostnames
@@ -65,7 +65,7 @@ fi
 if [ ! -z "${ERRORFILE}" ]; then
   echo $errors >${ERRORFILE}
 fi
-if [[ "$error" = true ]]; then
+if [[ "$error" == true ]]; then
   exit ${OCERROR}
 else
   exit ${OCOK}

--- a/pre/dns-hostnames
+++ b/pre/dns-hostnames
@@ -65,7 +65,7 @@ fi
 if [ ! -z "${ERRORFILE}" ]; then
   echo $errors >${ERRORFILE}
 fi
-if [ "$error" = true ]; then
+if [[ "$error" = true ]]; then
   exit ${OCERROR}
 else
   exit ${OCOK}

--- a/pre/dns-hostnames
+++ b/pre/dns-hostnames
@@ -2,16 +2,20 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 BASEDOMAIN=$(yq e '.baseDomain' ${INSTALL_CONFIG_PATH} 2>/dev/null)
 
 if [ -z ${BASEDOMAIN} ]; then
   errors=$(("${errors}" + 1))
+  error=true
   msg ".baseDomain not found in ${INSTALL_CONFIG_PATH}"
 fi
 
 CLUSTERNAME=$(yq e '.metadata.name' ${INSTALL_CONFIG_PATH} 2>/dev/null)
 if [ -z ${CLUSTERNAME} ]; then
   errors=$(("${errors}" + 1))
+  error=true
   msg ".metadata.name not found in ${INSTALL_CONFIG_PATH}"
 fi
 
@@ -25,22 +29,26 @@ WILDCARD="foobar.apps."${CLUSTERNAME}"."${BASEDOMAIN}"."
 IP_API=$(dig +short ${API})
 if [ -z ${IP_API} ]; then
   errors=$(("${errors}" + 1))
+  error=true
   msg "${RED}${API} doesn't resolve${NOCOLOR}"
 fi
 
 IP_WILDCARD=$(dig +short ${WILDCARD})
 if [ -z ${IP_WILDCARD} ]; then
   errors=$(("${errors}" + 1))
+  error=true
   msg "${RED}${WILDCARD} doesn't resolve${NOCOLOR}"
 fi
 
 IP_API_REVERSE=$(dig +short -x ${IP_API})
 if [ -z ${IP_API_REVERSE} ]; then
   errors=$(("${errors}" + 1))
+  error=true
   msg "${YELLOW}api reverse not found${NOCOLOR}"
 else
   if [ ${IP_API_REVERSE} != ${API} ]; then
     errors=$(("${errors}" + 1))
+    error=true
     msg "${YELLOW}${API} doesn't match the reverse ${IP_API_REVERSE}${NOCOLOR}"
   fi
 fi
@@ -57,7 +65,7 @@ fi
 if [ ! -z "${ERRORFILE}" ]; then
   echo $errors >${ERRORFILE}
 fi
-if [ "errors" != "0" ]; then
+if [ "$error" = true ]; then
   exit ${OCERROR}
 else
   exit ${OCOK}

--- a/ssh/bz1941840
+++ b/ssh/bz1941840
@@ -23,7 +23,7 @@ if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; 
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" = true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/ssh/bz1941840
+++ b/ssh/bz1941840
@@ -23,7 +23,7 @@ if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; 
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [[ "$error" = true ]]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/ssh/bz1941840
+++ b/ssh/bz1941840
@@ -4,6 +4,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+error=false
+
 if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; then
   msg "Checking for a hung kubelet..."
   # shellcheck disable=SC2016
@@ -15,12 +17,13 @@ if oc auth can-i get pods -n openshift-authentication-operator >/dev/null 2>&1; 
     if [ -n "${AUTH_OPERATOR_MEMORY}" ] && [ "${AUTH_OPERATOR_MEMORY}" -gt 2147483648 ]; then # more than 2GB is a bad sign
       msg "${RED}High memory usage detected for openshift-authentication-operator, which likely means that kubelet on ${node} is hung. Terminate the pod to remediate${NOCOLOR}"
       errors=$(("${errors}" + 1))
+      error=true
     fi
   fi
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "errors" != "0" ]; then
+  if [ "$error" = true ]; then
     exit ${OCERROR}
   else
     exit ${OCOK}


### PR DESCRIPTION
"errors" is a cumulative counter that is exported to each check, it is, therefore, incorrect to use it to check whether the current script failed. Once one check fails, all subsequent scripts will report "OCERROR". I added a local "error" variable that is used to report whether the check failed. This corrects the return values for these scripts.

The port-thrasing check was also missing returns for OCERROR and OCOK, so I added them.

My purpose in fixing this was to hopefully add some kind of "--results-only" mode in a future PR, which would just print the name of the script/check, and whether it was successful or not. If the user sees a failure, they can then just run that single script if they want, using the -s flag, to see the output from the script that failed.