### PR TITLE
export NOCOLOR

### DIFF
--- a/utils
+++ b/utils
@@ -46,10 +46,10 @@ cleanup() {
 
 setup_colors() {
   if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
-    NOCOLOR='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+    export NOCOLOR='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
   else
     # shellcheck disable=2034
-    NOCOLOR='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+    export NOCOLOR='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
   fi
 }
 


### PR DESCRIPTION
NOCOLOR needs to be exported so that the text coloring works in the check scripts (for instance https://github.com/RHsyseng/openshift-checks/blob/490dd6b7e1baba0ef42b8674c49e710921aeb2aa/checks/operators#L9)