### PR TITLE
[enhancement] Add check for Physical Volume Claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | [operators](checks/operators)                         | Checks if there are operators in 'bad' state                                                                              |
 | [pdb](checks/pdb)                                     | Checks if there are PodDisruptionBudgets with 0 disruptions allowed                                                  |
 | [port-thrasing](checks/port-thrasing)                 | Checks if there are OVN pods thrasing                                                                                     |
+| [pvc](checks/pvc)                                     | Checks if there are physical volume claims that are not bound                                                                                     |
 | [restarts](checks/restarts)                           | Checks if there are pods restarted > `n` times (10 by default)                                                            |
 | [terminating](checks/terminating)                     | Checks if there are pods terminating                                                                                      |
 | [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) | Checks if the memory usage of the OVN pods is under the LIMIT threshold                                                   |

--- a/checks/pvc
+++ b/checks/pvc
@@ -15,7 +15,7 @@ if oc auth can-i get pvc -A >/dev/null 2>&1; then
   if [ ! -z "${ERRORFILE}" ]; then
     echo $errors >${ERRORFILE}
   fi
-  if [ "$error" = true ]; then
+  if [[ "$error" == true ]]; then
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/pvc
+++ b/checks/pvc
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+[ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
+
+error=false
+
+if oc auth can-i get pvc -A >/dev/null 2>&1; then
+  pvc_not_bound=$(oc get pvc -A -o json | jq '.items[] | { name: .metadata.name, namespace: .metadata.namespace, phase: .status.phase } | select (.phase!="Bound")')
+  if [[ -n ${pvc_not_bound} ]]; then
+    PVCNOTBOUND=$(echo "${pvc_not_bound}" | jq .)
+    msg "Physical Volume Claims ${RED}NotBound${NOCOLOR}: ${PVCNOTBOUND}"
+    errors=$(("${errors}" + 1))
+    error=true
+  fi
+  if [ ! -z "${ERRORFILE}" ]; then
+    echo $errors >${ERRORFILE}
+  fi
+  if [ "$error" = true ]; then
+    exit ${OCERROR}
+  else
+    exit ${OCOK}
+  fi
+
+else
+  msg "Couldn't get pvc, check permissions"
+  exit ${OCSKIP}
+fi
+exit ${OCUNKNOWN}


### PR DESCRIPTION
This adds a check for PVCs. It will throw an error if there are any PVCs that are not Bound (the other possible states are Pending or Lost). See https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimStatus