### PR TITLE
[bugfix] Better SNO support

### DIFF
--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -5,8 +5,7 @@
 error=false
 
 if oc auth can-i get nodes >/dev/null 2>&1; then
-  SNO=$(oc get nodes -o json | jq '.items | length')
-  if [ ${SNO} -eq 1 ]; then
+  if [ $(is_sno) -eq 1 ]; then
     exit ${OCSKIP}
   fi
   scheduable_controllers=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, scheduable: .spec.taints, control: .metadata.labels."node-role.kubernetes.io/master" } | select((.control == "") and (.scheduable == null))')

--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -5,6 +5,10 @@
 error=false
 
 if oc auth can-i get nodes >/dev/null 2>&1; then
+  SNO=$(oc get nodes -o json | jq '.items | length')
+  if [ ${SNO} -eq 1 ]; then
+    exit ${OCOK}
+  fi
   scheduable_controllers=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, scheduable: .spec.taints, control: .metadata.labels."node-role.kubernetes.io/master" } | select((.control == "") and (.scheduable == null))')
   if [[ -n ${scheduable_controllers} ]]; then
     SCHEDCTRL=$(echo "${scheduable_controllers}" | jq '. | { name: .name }')

--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -7,7 +7,7 @@ error=false
 if oc auth can-i get nodes >/dev/null 2>&1; then
   SNO=$(oc get nodes -o json | jq '.items | length')
   if [ ${SNO} -eq 1 ]; then
-    exit ${OCOK}
+    exit ${OCSKIP}
   fi
   scheduable_controllers=$(oc get nodes -o json | jq '.items[] | { name: .metadata.name, scheduable: .spec.taints, control: .metadata.labels."node-role.kubernetes.io/master" } | select((.control == "") and (.scheduable == null))')
   if [[ -n ${scheduable_controllers} ]]; then

--- a/checks/pdb
+++ b/checks/pdb
@@ -7,7 +7,7 @@ error=false
 if oc auth can-i get pdb >/dev/null 2>&1; then
   SNO=$(oc get nodes -o json | jq '.items | length')
   if [ ${SNO} -eq 1 ]; then
-    exit ${OCOK}
+    exit ${OCSKIP}
   fi
   wrong_pdb=$(oc get pdb -A -o json | jq '.items[] | { name: .metadata.name, status: .status } | select (.status.disruptionsAllowed == 0) | { name: .name}')
   if [[ -n $wrong_pdb ]]; then

--- a/checks/pdb
+++ b/checks/pdb
@@ -5,6 +5,10 @@
 error=false
 
 if oc auth can-i get pdb >/dev/null 2>&1; then
+  SNO=$(oc get nodes -o json | jq '.items | length')
+  if [ ${SNO} -eq 1 ]; then
+    exit ${OCOK}
+  fi
   wrong_pdb=$(oc get pdb -A -o json | jq '.items[] | { name: .metadata.name, status: .status } | select (.status.disruptionsAllowed == 0) | { name: .name}')
   if [[ -n $wrong_pdb ]]; then
     DEGRADED=$(echo "${wrong_pdb}" | jq .)

--- a/checks/pdb
+++ b/checks/pdb
@@ -5,8 +5,7 @@
 error=false
 
 if oc auth can-i get pdb >/dev/null 2>&1; then
-  SNO=$(oc get nodes -o json | jq '.items | length')
-  if [ ${SNO} -eq 1 ]; then
+  if [ $(is_sno) -eq 1 ]; then
     exit ${OCSKIP}
   fi
   wrong_pdb=$(oc get pdb -A -o json | jq '.items[] | { name: .metadata.name, status: .status } | select (.status.disruptionsAllowed == 0) | { name: .name}')

--- a/utils
+++ b/utils
@@ -155,3 +155,12 @@ oc_whoami() {
     echo "${WHOAMI}"
   fi
 }
+
+is_sno() {
+  local SNO=$(oc get nodes -o json | jq '.items | length')
+  if [ ${SNO} -eq 1 ]; then
+    echo 1
+  else
+    echo 0
+  fi
+}


### PR DESCRIPTION
The ctrlnodes and pdb check fail on SNO.

Ctrlnodes fails for obvious reasons (the master node is schedulable). PDB check fails because of this:

```
PodDisruptionBudget with 0 disruptions allowed: {
  "name": "ovn-raft-quorum-guard"
}
```

Disrupted pods have nowhere to go on SNO, so it makes sense to be to skip this check for SNO.