### PR TITLE
[enhancement/bugfix] Make zombie a check and fix error return for parallel jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | [restarts](checks/restarts)                           | Checks if there are pods restarted > `n` times (10 by default)                                                            |
 | [terminating](checks/terminating)                     | Checks if there are pods terminating                                                                                      |
 | [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) | Checks if the memory usage of the OVN pods is under the LIMIT threshold                                                   |
+| [zombies](checks/zombies)                             | Checks if more than 5 zombie processes exist on the hosts                     |
 
 ### SSH Checks
 
@@ -136,8 +137,7 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | [mtu](info/mtu)                                             | Show the nodes' MTU for some interfaces                             |
 | [node-versions](info/node-versions)                         | Show node components versions such as kubelet, crio, kernel, etc.   |
 | [ovs-hostnames](info/ovs-hostnames)                         | Show the ovs database chassis hostnames                             |
-| [zombies](checks/zombies)                                   | Show if there are zombie processes in the hosts                     |
-| [locks](checks/locks)                                       | List all pods with locks on each node                               |
+| [locks](info/locks)                                         | List all pods with locks on each node                               |
 
 ### Prechecks
 

--- a/checks/chronyc
+++ b/checks/chronyc
@@ -2,7 +2,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
-error=false
+tmperrorfile=$(mktemp)
+echo 0 > $tmperrorfile
 
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Collecting NTP data... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
@@ -17,17 +18,17 @@ if oc auth can-i debug node >/dev/null 2>&1; then
       else
         if [ -n "${SOURCES}" ] && [ "${SOURCES}" -lt 1 ]; then
           msg "${RED}Clock doesn't seem to be synced in ${node}${NOCOLOR}"
-          errors=$(("${errors}" + 1))
-          error=true
+          echo 1 > $tmperrorfile
         fi
       fi
     ) &
   done
   wait
-  if [ ! -z "${ERRORFILE}" ]; then
-    echo $errors >${ERRORFILE}
-  fi
-  if [[ "$error" == true ]]; then
+  if [ "$(cat $tmperrorfile)" -eq 1 ]; then
+    errors=$(("${errors}" + 1))
+    if [ ! -z "${ERRORFILE}" ]; then
+      echo $errors >${ERRORFILE}
+    fi
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/entropy
+++ b/checks/entropy
@@ -2,7 +2,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
-error=false
+tmperrorfile=$(mktemp)
+echo 0 > $tmperrorfile
 
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Collecting entropy data... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
@@ -16,17 +17,17 @@ if oc auth can-i debug node >/dev/null 2>&1; then
       else
         if [ -n "${ENTROPY}" ] && [ "${ENTROPY}" -lt 200 ]; then
           msg "${RED}Low entropy in ${node}${NOCOLOR}"
-          errors=$(("${errors}" + 1))
-          error=true
+          echo 1 > $tmperrorfile
         fi
       fi
     ) &
   done
   wait
-  if [ ! -z "${ERRORFILE}" ]; then
-    echo $errors >${ERRORFILE}
-  fi
-  if [[ "$error" == true ]]; then
+  if [ "$(cat $tmperrorfile)" -eq 1 ]; then
+    errors=$(("${errors}" + 1))
+    if [ ! -z "${ERRORFILE}" ]; then
+      echo $errors >${ERRORFILE}
+    fi
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/iptables-22623-22624
+++ b/checks/iptables-22623-22624
@@ -11,7 +11,8 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
-error=false
+tmperrorfile=$(mktemp)
+echo 0 > $tmperrorfile
 
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Checking if ports 22623/tcp and 22624/tcp are blocked (${BLUE}using oc debug, it can take a while${NOCOLOR})"
@@ -39,16 +40,16 @@ if oc auth can-i debug node >/dev/null 2>&1; then
         msg "${ORANGE}Unable to create debug pod in ${node}${NOCOLOR}"
       else
         msg "${RED}iptables rules for 22623/tcp or 22624/tcp found in ${node}${NOCOLOR}"
-        errors=$(("${errors}" + 1))
-        error=true
+        echo 1 > $tmperrorfile
       fi
     ) &
   done
   wait
-  if [ ! -z "${ERRORFILE}" ]; then
-    echo $errors >${ERRORFILE}
-  fi
-  if [[ "$error" == true ]]; then
+  if [ "$(cat $tmperrorfile)" -eq 1 ]; then
+    errors=$(("${errors}" + 1))
+    if [ ! -z "${ERRORFILE}" ]; then
+      echo $errors >${ERRORFILE}
+    fi
     exit ${OCERROR}
   else
     exit ${OCOK}

--- a/checks/zombies
+++ b/checks/zombies
@@ -2,6 +2,9 @@
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 
+tmperrorfile=$(mktemp)
+echo 0 > $tmperrorfile
+
 if oc auth can-i debug node >/dev/null 2>&1; then
   msg "Collecting zombie processes... (${BLUE}using oc debug, it can take a while${NOCOLOR})"
   # shellcheck disable=SC2016
@@ -12,11 +15,22 @@ if oc auth can-i debug node >/dev/null 2>&1; then
       ZOMBIES=$(oc debug --image="${OCDEBUGIMAGE}" "${node}" -- chroot /host sh -c 'ps -ef | grep -c "[d]efunct"' 2>/dev/null)
       if [ -n "${ZOMBIES}" ] && [ "${ZOMBIES}" -gt 0 ]; then
           msg "${ORANGE}${ZOMBIES}${NOCOLOR} zombie processes found in ${node}"
+          if [ "${ZOMBIES}" -ge 5 ]; then
+            echo 1 > $tmperrorfile
+          fi
       fi
     ) &
   done
   wait
-  exit ${OCINFO}
+  if [ "$(cat $tmperrorfile)" -eq 1 ]; then
+    errors=$(("${errors}" + 1))
+    if [ ! -z "${ERRORFILE}" ]; then
+      echo $errors >${ERRORFILE}
+    fi
+    exit ${OCERROR}
+  else
+    exit ${OCOK}
+  fi
 else
   msg "Couldn't debug nodes, check permissions"
   exit ${OCSKIP}


### PR DESCRIPTION
This moves "zombies" from info to check, and fails if there are 5 or more zombies.

Additionally, I noticed that there is a problem with error checking when using parallel processes.

Because the checks are done in a subprocess, any edits to "errors" aren't reflected in the main check script. Instead, I write a "1" to a temporary file, and use that to check for errors once all the processes have completed.