### PR TITLE
Pdb check throwing errors 

### DIFF
--- a/checks/pdb
+++ b/checks/pdb
@@ -12,7 +12,7 @@ if oc auth can-i get pdb >/dev/null 2>&1; then
   if [[ -n $wrong_pdb ]]; then
     DEGRADED=$(echo "${wrong_pdb}" | jq .)
     msg "PodDisruptionBudget with 0 disruptions allowed: ${RED}${DEGRADED}${NOCOLOR}"
-    errors=$(("${errors}" + 1))
+    errors=$((${errors} + 1))
     error=true
   fi
   if [ ! -z "${ERRORFILE}" ]; then


### PR DESCRIPTION
Raising a pull request for the below error message received on the cluster when running the `checks/pdb`

~~~

Running in -x mode for the script 

$ ./openshift-checks.sh -s checks/pdb
Using xxxxxxxx context
+ '[' -z ']'
+++ dirname checks/pdb
++ echo checks/../utils
+ source checks/../utils
++ OCOK=0
++ OCINFO=1
++ OCERROR=2
++ OCSKIP=3
++ OCUNKNOWN=4
++ PARALLELJOBS=1
+ error=false
+ oc auth can-i get pdb
++ is_sno
+++ oc get nodes -o json
+++ jq '.items | length'
++ local SNO=9
++ '[' 9 -eq 1 ']'
++ echo 0
+ '[' 0 -eq 1 ']'
++ oc get pdb -A -o json
++ jq '.items[] | { name: .metadata.name, status: .status } | select (.status.disruptionsAllowed == 0) | { name: .name}'
+ wrong_pdb='{
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
}'
+ [[ -n {
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
} ]]
++ echo '{
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
}'
++ jq .
+ DEGRADED='{
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
}'
+ msg 'PodDisruptionBudget with 0 disruptions allowed: \033[0;31m{
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
}\033[0m'
+ echo -e 'PodDisruptionBudget with 0 disruptions allowed: \033[0;31m{
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
}\033[0m'
PodDisruptionBudget with 0 disruptions allowed: {
  "name": "rockallelasticlocal-master-pdb"
}
{
  "name": "router-customer-ingress-controller"
}
checks/pdb: line 15: "" + 1: syntax error: operand expected (error token is """ + 1")
+ exit
No issues found


$ oc get pdb -A
NAMESPACE                            NAME                                 MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
xxxx-xxxx-xxxxx                      rockallelasticlocal-master-pdb       N/A             1                 0                     352d
openshift-ingress                    router-customer-ingress-controller   N/A             50%               0                     471d
~~~
