### PR TITLE
Adding clarification about the Node subnet

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ This script gives the potential list of commands to clean up wrong conntracks
 It only supports UDP stale entries
 It only considers clusterIP services
 It only works on IPV4 single stack env
-Assumes node subnet is the default /24 cidr
+Assumes node subnet is the default /24 cidr (it also works for /23)
 Assumes Cluster CIDR is /16
 Checks for the Service CIDR to have one of the networks /8 /16 or /24
 

--- a/scripts/ovn_cleanConntrack.sh
+++ b/scripts/ovn_cleanConntrack.sh
@@ -8,7 +8,7 @@
 NOW=$(date +"%Y-%m-%d_%H-%M-%S")
 # Logfile to save some DEBUG output
 LOG="/tmp/ovn_cleanConntrack.sh.${NOW}.log"
-# IP of the ovn-k8s-mp0 interface for a node subnet with mask /24
+# IP of the ovn-k8s-mp0 interface for a node subnet with mask /24 or /23
 NODESUBNETIP=2
 # Debug var to write DEBUG lines into the log
 DEBUG=false
@@ -27,7 +27,7 @@ function usage() {
   echo "It only supports UDP stale entries"
   echo "It only considers clusterIP services"
   echo "It only works on IPV4 single stack env"
-  echo "Assumes node subnet is the default /24 cidr"
+  echo "Assumes node subnet is the default /24 cidr (it also works for /23)"
   echo "Assumes Cluster CIDR is /16"
   echo "Checks for the Service CIDR to have one of the networks /8 /16 or /24"
   echo -e


### PR DESCRIPTION
The actual calculations for the node subnet are based in /24 networks.
The logic remains the same for /23 networks since mp0 IP will always be "gatewayIP of the range which is for example 10.131.0.1 + increment that by one" which is 10.131.0.2. 
Adding some comments in the README and the code to clarify that.

The Golang logic that OVNK uses is:
```
// GetNodeGatewayIfAddr returns the node logical switch gateway address
// (the ".1" address)
func GetNodeGatewayIfAddr(subnet *net.IPNet) *net.IPNet {
    return &net.IPNet{IP: NextIP(subnet.IP), Mask: subnet.Mask}
}

// GetNodeManagementIfAddr returns the node logical switch management port address
// (the ".2" address)
func GetNodeManagementIfAddr(subnet *net.IPNet) *net.IPNet {
    gwIfAddr := GetNodeGatewayIfAddr(subnet)
    return &net.IPNet{IP: NextIP(gwIfAddr.IP), Mask: subnet.Mask}
}
``` 