### PR TITLE
feat: autogenerate checks.md out of descriptions in checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ A set of scripts to run basic checks on an OpenShift cluster. PRs welcome!
     - [CronJob](#cronjob)
   - [How it works](#how-it-works)
     - [Checks](#checks)
-    - [SSH Checks](#ssh-checks)
-    - [Info](#info)
-    - [Prechecks](#prechecks)
     - [Environment variables](#environment-variables)
     - [About firmware version](#about-firmware-version)
   - [Collaborate](#collaborate)
@@ -116,61 +113,9 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 
 ### Checks
 
-| Script                                                        | Description                                                                                                               |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [alertmanager](checks/alertmanager)                           | Checks if there are warning or error alerts firing                                                                        |
-| [bz1948052](checks/bz1948052)                                 | Checks if the node is using a kernel version affected by [BZ1948052](https://bugzilla.redhat.com/show_bug.cgi?id=1948052) |
-| [chronyc](checks/chronyc)                                     | Checks if the worker clocks are synced using chronyc                                                                      |
-| [clusterversion_errors](checks/clusterversion_errors)         | Checks if there are clusterversion errors                                                                                 |
-| [csr](checks/csr)                                             | Checks if there are pending csr                                                                                           |
-| [ctrlnodes](checks/ctrlnodes)                                 | Checks if any controller nodes have had the NoSchedule taint removed                                                      |
-| [entropy](checks/entropy)                                     | Checks if the workers have enough entropy                                                                                 |
-| [iptables-22623-22624](checks/iptables-22623-22624)           | Checks if the nodes iptables rules are blocking 22623/tpc or 22624/tcp                                                    |
-| [mcp](checks/mcp)                                             | Checks if there are degraded mcp                                                                                          |
-| [mellanox-firmware-version](checks/mellanox-firmware-version) | Checks if the nodes' Mellanox Connect-4 firmware version is below the recommended version.                                |
-| [nodes](checks/nodes)                                         | Checks if there are not ready or not schedulable nodes                                                                    |
-| [notrunningpods](checks/notrunningpods)                       | Checks if there are not running pods                                                                                      |
-| [operators](checks/operators)                                 | Checks if there are operators in 'bad' state                                                                              |
-| [pdb](checks/pdb)                                             | Checks if there are PodDisruptionBudgets with 0 disruptions allowed                                                       |
-| [port-thrashing](checks/port-thrashing)                       | Checks if there are OVN pods thrashing                                                                                     |
-| [pvc](checks/pvc)                                             | Checks if there are persistent volume claims that are not bound                                                           |
-| [restarts](checks/restarts)                                   | Checks if there are pods restarted > `n` times (10 by default)                                                            |
-| [sriov](checks/sriov)                                         | Checks if the SR-IOV network state is synced                                                                              |
-| [terminating](checks/terminating)                             | Checks if there are pods terminating                                                                                      |
-| [ovn-pods-memory-usage](checks/ovn-pods-memory-usage)         | Checks if the memory usage of the OVN pods is under the LIMIT threshold                                                   |
-| [zombies](checks/zombies)                                     | Checks if more than 5 zombie processes exist on the hosts                                                                 |
+Check each script and its description in [checks](checks.md)
 
-### SSH Checks
-
-| Script                     | Description                                                                                                                                   |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [bz1941840](ssh/bz1941840) | Checks if the authentication-operator is using excessive RAM -> hung kubelet [BZ1941840](https://bugzilla.redhat.com/show_bug.cgi?id=1948052) |
-
-### Info
-
-| Script                                                      | Description                                                         |
-| ----------------------------------------------------------- | ------------------------------------------------------------------- |
-| [clusterversion](info/00-clusterversion)                    | Show the clusterversion                                             |
-| [clusteroperators](info/01-clusteroperators)                | Show the clusteroperators                                           |
-| [nodes](info/02-nodes)                                      | Show the nodes status                                               |
-| [pods](info/03-pods)                                        | Show the pods running in the cluster                                |
-| [machineset](info/04-machineset)                            | Show the machinesets status                                         |
-| [biosversion](info/biosversion)                             | Show the nodes' BIOS version                                        |
-| [bmh-machine-node](info/bmh-machine-node)                   | Show the node,machine and bmh relationship                          |
-| [container-images-running](info/container-images-running)   | Show the images of the containers running in the cluster            |
-| [container-images-stored](info/container-images-stored)     | Show the container images stored in the cluster hosts               |
-| [ethtool-firmware-version](info/ethtool-firmware-version)   | Show the nodes' NIC firmware version using ethtool                  |
-| [mtu](info/mtu)                                             | Show the nodes' MTU for some interfaces                             |
-| [node-versions](info/node-versions)                         | Show node components versions such as kubelet, crio, kernel, etc.   |
-| [ovs-hostnames](info/ovs-hostnames)                         | Show the ovs database chassis hostnames                             |
-| [locks](info/locks)                                         | List all pods with locks on each node                               |
-
-### Prechecks
-
-| Script                                                        | Description                                                 |
-| ------------------------------------------------------------- | ----------------------------------------------------------- |
-| [install-config-valid-yaml](pre/00-install-config-valid-yaml) | Checks if the install-config.yaml file is a valid yaml file |
-| [dns-hostnames](pre/dns-hostnames)                            | Checks if the api and wildcard DNS entries are correct      |
+Note: This file is autogenerated when running: `./scripts/update-checksmd  > checks.md`
 
 ### Environment variables
 
@@ -180,15 +125,13 @@ in the [info](./info), [checks](./checks) or [ssh](./ssh) directories.
 | OCDEBUGIMAGE         | registry.redhat.io/rhel8/support-tools:latest        | Used by `oc debug`.                                                                                                                      |
 | OSETOOLSIMAGE        | registry.redhat.io/openshift4/ose-tools-rhel8:latest | Used by `oc debug` in [ethtool-firmware-version](info/ethtool-firmware-version)                                                          |
 | RESTART_THRESHOLD    | 10                                                   | Used by the [restarts](checks/restarts) script.                                                                                          |
-| THRASHING_THRESHOLD   | 10                                                  | Used by the [port-thrashing](checks/port-thrashing) script.                                                                              |
+| THRASHING_THRESHOLD  | 10                                                   | Used by the [port-thrashing](checks/port-thrashing) script.                                                                              |
 | PARALLELJOBS         | 1                                                    | By default, all the `oc debug` commands run in a serial fashion, unless this variable is set >1                                          |
 | OVN_MEMORY_LIMIT     | 5000                                                 | Used by the [ovn-pods-memory-usage](checks/ovn-pods-memory-usage) script to set the maximum memory LIMIT (in Mi) to trigger the warning. |
 
 ### About firmware version
 
-The current [intel-firmware-version](info/intel-firmware-version) and
-[mellanox-firmware-version](info/mellanox-firmware-version) checks only check
-the firmware version of the SRIOV operator supported NICs ([in 4.6](https://docs.openshift.com/container-platform/4.6/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov)).
+The current script checks only the firmware version of the SRIOV operator supported NICs ([in 4.6](https://docs.openshift.com/container-platform/4.6/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov)).
 
 You can add your own device ID if needed by modifying the script (hint, the
 variable is called `IDS` and the format is `vendorID_A:deviceID_A vendorID_B:deviceID_B`)
@@ -198,6 +141,8 @@ variable is called `IDS` and the format is `vendorID_A:deviceID_A vendorID_B:dev
 Add a new script to get some information or to perform some check in the proper
 folder and create a pull request.
 
+Make sure you include a `# description: $TEXT` that will be later used to populate the `checks.md` file with the description.
+
 ## Tips & Tricks
 
 ### Send an email if some check fails
@@ -205,7 +150,7 @@ folder and create a pull request.
 You can pipe the script to `mail` and if there are any errors, an email will be
 sent.
 
-First you can configure postfix (already included in RHEL8) as relay host
+First, you can configure postfix (already included in RHEL8) as relay host
 (see https://access.redhat.com/solutions/217503). As an example:
 
 - Append the following settings in `/etc/postfix/main.cf`:
@@ -233,11 +178,11 @@ Then, run the script as:
 /openshift-checks.sh > /tmp/oc-errors 2>&1 || mail -s "Something has failed" johndoe@example.com < /tmp/oc-errors
 ```
 
-As a bonus you can include this in a cronjob for periodic checks.
+As a bonus, you can include this in a cronjob for periodic checks.
 
 ### Get JSON and HTML output
 
-This requires installation of python requirements in the `requirements.txt` file, preferable within a virtual environment, once those are installed execute:
+This requires the installation of python requirements in the `requirements.txt` file, recommended within a virtual environment, once those are installed execute:
 
 ```bash
 ./risu.py -l
@@ -248,6 +193,6 @@ To automatically execute the tests against the current environment and generate 
 - `osc.json`
 - `osc.html`
 
-When loaded over a web server, the html file will pull the `json` file over AJAX and represent the results of the tests in a graphical way:
+When loaded over a web server, the HTML file will pull the `json` file over AJAX and represent the results of the tests in a graphical way:
 
 ![](webreport.png)

--- a/checks.md
+++ b/checks.md
@@ -1,0 +1,57 @@
+# info
+
+| Script                                                         | Description                                                       |
+| -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [info/ovs-hostnames](info/ovs-hostnames)                       | Show the ovs database chassis hostnames                           |
+| [info/node-versions](info/node-versions)                       | Show node components versions such as kubelet, crio, kernel, etc. |
+| [info/container-images-running](info/container-images-running) | Show the images of the containers running in the cluster          |
+| [info/01-clusteroperators](info/01-clusteroperators)           | Show the clusteroperators                                         |
+| [info/00-clusterversion](info/00-clusterversion)               | Show the clusterversion                                           |
+| [info/03-pods](info/03-pods)                                   | Show the pods running in the cluster                              |
+| [info/02-nodes](info/02-nodes)                                 | Show the nodes status                                             |
+| [info/04-machineset](info/04-machineset)                       | Show the machinesets status                                       |
+| [info/bmh-machine-node](info/bmh-machine-node)                 | Show the node,machine and bmh relationship                        |
+| [info/biosversion](info/biosversion)                           | Show the nodes' BIOS version                                      |
+| [info/container-images-stored](info/container-images-stored)   | Show the container images stored in the cluster hosts             |
+| [info/ethtool-firmware-version](info/ethtool-firmware-version) | Show the nodes' NIC firmware version using ethtool                |
+| [info/locks](info/locks)                                       | List all pods with locks on each node                             |
+| [info/mtu](info/mtu)                                           | Show the nodes' MTU for some interfaces                           |
+
+# pre
+
+| Script                                                               | Description                                                 |
+| -------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [pre/00-install-config-valid-yaml](pre/00-install-config-valid-yaml) | Checks if the install-config.yaml file is a valid yaml file |
+| [pre/dns-hostnames](pre/dns-hostnames)                               | Checks if the api and wildcard DNS entries are correct      |
+
+# ssh
+
+| Script                         | Description                                                                            |
+| ------------------------------ | -------------------------------------------------------------------------------------- |
+| [ssh/bz1941840](ssh/bz1941840) | Checks if the authentication-operator is using excessive RAM -> hung kubelet BZ1941840 |
+
+# checks
+
+| Script                                                               | Description                                                                                |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [checks/pvc](checks/pvc)                                             | Checks if there are persistent volume claims that are not bound                            |
+| [checks/entropy](checks/entropy)                                     | Checks if the workers have enough entropy                                                  |
+| [checks/mellanox-firmware-version](checks/mellanox-firmware-version) | Checks if the nodes' Mellanox Connect-4 firmware version is below the recommended version. |
+| [checks/port-thrashing](checks/port-thrashing)                       | Checks if there are OVN pods thrashing                                                     |
+| [checks/alertmanager](checks/alertmanager)                           | Checks if there are warning or error alerts firing                                         |
+| [checks/restarts](checks/restarts)                                   | Checks if there are pods restarted > n times (10 by default)                               |
+| [checks/clusterversion_errors](checks/clusterversion_errors)         | Checks if there are clusterversion errors                                                  |
+| [checks/terminating](checks/terminating)                             | Checks if there are pods terminating                                                       |
+| [checks/pdb](checks/pdb)                                             | Checks if there are PodDisruptionBudgets with 0 disruptions allowed                        |
+| [checks/ovn-pods-memory-usage](checks/ovn-pods-memory-usage)         | Checks if the memory usage of the OVN pods is under the LIMIT threshold                    |
+| [checks/mcp](checks/mcp)                                             | Checks if there are degraded mcp                                                           |
+| [checks/notrunningpods](checks/notrunningpods)                       | Checks if there are not running pods                                                       |
+| [checks/csr](checks/csr)                                             | Checks if there are pending csr                                                            |
+| [checks/ctrlnodes](checks/ctrlnodes)                                 | Checks if any controller nodes have had the NoSchedule taint removed                       |
+| [checks/sriov](checks/sriov)                                         | Checks if the SR-IOV network state is synced                                               |
+| [checks/bz1948052](checks/bz1948052)                                 | Checks for BZ 1948052 based on kernel version                                              |
+| [checks/nodes](checks/nodes)                                         | Checks if there are not ready or not schedulable nodes                                     |
+| [checks/operators](checks/operators)                                 | Checks if there are operators in 'bad' state                                               |
+| [checks/chronyc](checks/chronyc)                                     | Checks if the worker clocks are synced using chronyc                                       |
+| [checks/iptables-22623-22624](checks/iptables-22623-22624)           | Checks if the nodes iptables rules are blocking 22623/tpc or 22624/tcp                     |
+| [checks/zombies](checks/zombies)                                     | Checks if more than 5 zombie processes exist on the hosts                                  |

--- a/checks/alertmanager
+++ b/checks/alertmanager
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# description: Checks if there are warning or error alerts firing
 # kb: https://access.redhat.com/solutions/4250221
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")

--- a/checks/chronyc
+++ b/checks/chronyc
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the worker clocks are synced using chronyc
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/clusterversion_errors
+++ b/checks/clusterversion_errors
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are clusterversion errors
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/csr
+++ b/checks/csr
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are pending csr
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/ctrlnodes
+++ b/checks/ctrlnodes
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if any controller nodes have had the NoSchedule taint removed
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/entropy
+++ b/checks/entropy
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the workers have enough entropy
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/iptables-22623-22624
+++ b/checks/iptables-22623-22624
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # kb: https://access.redhat.com/solutions/5709711
+# description: Checks if the nodes iptables rules are blocking 22623/tpc or 22624/tcp
+
 #
 # To check if the rule exist, we use iptables -C, it returns 0 if the rule exist
 # and if it doesn't exist, it exits 1 with the following message:

--- a/checks/mcp
+++ b/checks/mcp
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are degraded mcp
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/mellanox-firmware-version
+++ b/checks/mellanox-firmware-version
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the nodes' Mellanox Connect-4 firmware version is below the recommended version.
 
 # lspci -nn shows PCI vendor and device codes (and names)
 # Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with **vendor ID 0x15b3 and device ID 0x1015**

--- a/checks/nodes
+++ b/checks/nodes
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are not ready or not schedulable nodes
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/notrunningpods
+++ b/checks/notrunningpods
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are not running pods
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/operators
+++ b/checks/operators
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are operators in 'bad' state
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/ovn-pods-memory-usage
+++ b/checks/ovn-pods-memory-usage
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the memory usage of the OVN pods is under the LIMIT threshold
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/pdb
+++ b/checks/pdb
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are PodDisruptionBudgets with 0 disruptions allowed
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/port-thrashing
+++ b/checks/port-thrashing
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are OVN pods thrashing
 
 THRASHINGMSG="Changing chassis for lport"
 NAMESPACE="openshift-ovn-kubernetes"

--- a/checks/pvc
+++ b/checks/pvc
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are persistent volume claims that are not bound
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/restarts
+++ b/checks/restarts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are pods restarted > n times (10 by default)
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/sriov
+++ b/checks/sriov
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the SR-IOV network state is synced
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/terminating
+++ b/checks/terminating
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if there are pods terminating
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/checks/zombies
+++ b/checks/zombies
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if more than 5 zombie processes exist on the hosts
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/00-clusterversion
+++ b/info/00-clusterversion
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the clusterversion
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/01-clusteroperators
+++ b/info/01-clusteroperators
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the clusteroperators
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/02-nodes
+++ b/info/02-nodes
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the nodes status
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/03-pods
+++ b/info/03-pods
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the pods running in the cluster
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/04-machineset
+++ b/info/04-machineset
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the machinesets status
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/biosversion
+++ b/info/biosversion
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the nodes' BIOS version
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/bmh-machine-node
+++ b/info/bmh-machine-node
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the node,machine and bmh relationship
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/container-images-running
+++ b/info/container-images-running
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the images of the containers running in the cluster
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/container-images-stored
+++ b/info/container-images-stored
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the container images stored in the cluster hosts
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/ethtool-firmware-version
+++ b/info/ethtool-firmware-version
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the nodes' NIC firmware version using ethtool
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/locks
+++ b/info/locks
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: List all pods with locks on each node
 
 ORIG_IFS=$IFS
 IFS=$(echo -en "\n\b")

--- a/info/mtu
+++ b/info/mtu
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the nodes' MTU for some interfaces
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/node-versions
+++ b/info/node-versions
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show node components versions such as kubelet, crio, kernel, etc.
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/info/ovs-hostnames
+++ b/info/ovs-hostnames
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Show the ovs database chassis hostnames
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/pre/00-install-config-valid-yaml
+++ b/pre/00-install-config-valid-yaml
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the install-config.yaml file is a valid yaml file
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/pre/dns-hostnames
+++ b/pre/dns-hostnames
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# description: Checks if the api and wildcard DNS entries are correct
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,7 +50,7 @@ $ ./ovn_cleanConntrack.sh -k /home/kni/clusterconfigs/cluster2/auth/kubeconfig
 $ ./ovn_cleanConntrack.sh -k /home/kni/clusterconfigs/cluster3/auth/kubeconfig
 ```
 
-In the previous example the script will analyse the clusters indicated by the kubeconfig files on /home/kni/clusterconfigs/cluster1/kubeconfig, /home/kni/clusterconfigs/cluster2/kubeconfig and /home/kni/clusterconfigs/cluster3/kubeconfig
+In the previous example, the script will analyse the clusters indicated by the kubeconfig files on `/home/kni/clusterconfigs/cluster1/kubeconfig`, `/home/kni/clusterconfigs/cluster2/kubeconfig` and `/home/kni/clusterconfigs/cluster3/kubeconfig`
 If no -k is indicated the script expects to have the KUBECONFIG variable exported in the system otherwise it will give an error because it can't connect.
 
 For the -q parameter, instead of printing the output to the standard output now you can indicate the file were to save the output of the script, to cover the commented use case for running on batch mode:
@@ -61,7 +61,7 @@ $ ./ovn_cleanConntrack.sh -k /home/kni/clusterconfigs/cluster2/auth/kubeconfig -
 $ ./ovn_cleanConntrack.sh -k /home/kni/clusterconfigs/cluster3/auth/kubeconfig -q /tmp/cluster3.output
 ```
 
-If no conntracks with issues are found the files /tmp/cluster?.output won't be created. If no -q is indicated, the script will print the results in the standard output.
+If no conntracks with issues are found the files `/tmp/cluster?.output` won't be created. If no -q is indicated, the script will print the results in the standard output.
 
 Here is an example on how to configure a cronjob to run the script every hour (you can place it on /etc/cron.d/1conntracks).
 This example uses the parameters -k and -q indicating the kubeconfig and the file to save the output:
@@ -76,7 +76,7 @@ MAILTO=root
 20 * * * * kni /usr/local/bin/ovn_cleanConntrack.sh -k /home/kni/clusterconfigs/cluster3/auth/kubeconfig -q /tmp/ovnconntracks_cluster3.log
 ```
 
-In that example the debug log is still being generated using the LOG var inside the script, but that is a debug log file in case we need to debug the script behaviour, and it can be modified according to bastion space and needs.
+In that example, the debug log is still being generated using the LOG var inside the script, but that is a debug log file in case we need to debug the script behaviour, and it can be modified according to bastion space and needs.
 
 ## recover-northd.sh
 
@@ -109,7 +109,7 @@ $ ./recover-northd.sh -k /home/kni/clusterconfigs/cluster2/auth/kubeconfig
 $ ./recover-northd.sh -k /home/kni/clusterconfigs/cluster3/auth/kubeconfig
 ```
 
-In the previous example the script will analyse the clusters indicated by the kubeconfig files on /home/kni/clusterconfigs/cluster1/kubeconfig, /home/kni/clusterconfigs/cluster2/kubeconfig and /home/kni/clusterconfigs/cluster3/kubeconfig
+In the previous example, the script will analyse the clusters indicated by the kubeconfig files on `/home/kni/clusterconfigs/cluster1/kubeconfig`, `/home/kni/clusterconfigs/cluster2/kubeconfig` and `/home/kni/clusterconfigs/cluster3/kubeconfig`
 If no -k is indicated the script expects to have the KUBECONFIG variable exported in the system otherwise it will give an error because it can't connect.
 
 For the -r parameter, the script will send an exit to the northd container for OVN to elect a new leader:

--- a/scripts/update-checksmd
+++ b/scripts/update-checksmd
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Updates the checks.md out of scripts in the folders 'headers'
+
+for kind in info pre ssh checks; do
+  echo """
+# ${kind}
+| Script | Description |
+| - | - |"""
+
+  for file in $(find ${kind} -type f -executable); do
+    echo "| [${file}](${file}) | $(grep '^# description:' ${file} | cut -d ":" -f 2-) |"
+  done
+done

--- a/ssh/bz1941840
+++ b/ssh/bz1941840
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# description: Checks if the authentication-operator is using excessive RAM -> hung kubelet BZ1941840
 # bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1948052
 
 [ -z ${UTILSFILE} ] && source $(echo "$(dirname ${0})/../utils")


### PR DESCRIPTION
README gets removed the list of checks that goes into individual file `checks.md`

The `checks.md` file is autogenerated by a script, out of the headers of the individual checks.

As a side effect, the HTML interface now reports what each plugin does:


![image](https://user-images.githubusercontent.com/312463/202685473-b5f2048f-10e0-4dc4-b9e6-f7c28ac04e8d.png)


I would advise about doing headers like the ones in this plugin from now on: https://github.com/RHsyseng/openshift-checks/blob/main/checks/bz1948052#L1-L5

